### PR TITLE
making ipfs pathing work

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@airswap/explorer",
   "version": "1.0.0",
   "license": "Apache-2.0",
+  "homepage": "./",
   "contributors": [
     "Shawn Kim <shawn.kim@fluidity.io>",
     "Sam Walker <sam.walker@fluidity.io>",


### PR DESCRIPTION
## Product Changes

Moved the homepage path to `./` to support the IPFS pathing added when access IPFS directly from the localhost.

- [ ] N/A
- [X] New features
- [x] Bug fixes
- [ ] UI tweaks

## Technical Summary

Added a `./` in front of the `static` directory and other directories when loading scripts. This now works with IPFS.

## How to Test

Run an IPFS node. Connect to http://127.0.0.1:8080/ipfs/QmPmEUW28XLcZAwCVhEXMKmENWh1XwAP2z6jgfn5XWWgpn/?timeframe=14
